### PR TITLE
Fix linux and mac build

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,7 +75,6 @@ cubbit_default["gn_args"] = [
     'rtc_include_opus=false',
     'rtc_include_pulse_audio=false',
     'rtc_use_dummy_audio_file_devices=true',
-    'rtc_use_gtk=false',
     'rtc_use_x11=false',
     'use_custom_libcxx=false',
 
@@ -83,7 +82,7 @@ cubbit_default["gn_args"] = [
     'rtc_disable_metrics=false',
     'rtc_build_tools=false',
     # 'rtc_exclude_transient_suppressor=true',
-    'rtc_disable_trace_events=true',
+    'rtc_disable_trace_events=false',
 ]
 
 patches = {}

--- a/patches/build_config_linux-4515.patch
+++ b/patches/build_config_linux-4515.patch
@@ -1,8 +1,8 @@
 diff --git a/config/linux/BUILD.gn b/config/linux/BUILD.gn
-index 8e42cf9f2..bd21cc143 100644
+index 47704248b..fb7e98ecf 100644
 --- a/config/linux/BUILD.gn
 +++ b/config/linux/BUILD.gn
-@@ -15,6 +15,23 @@ group("linux") {
+@@ -15,6 +15,22 @@ group("linux") {
  # is applied to all targets. It is here to separate out the logic that is
  # Linux-only. This is not applied to Android, but is applied to ChromeOS.
  config("compiler") {
@@ -22,7 +22,6 @@ index 8e42cf9f2..bd21cc143 100644
 +      "../../../../../libcxx/include/c++/v1",
 +    ]
 +  }
-+
-   if (current_cpu == "arm64") {
-     import("//build/config/arm.gni")
-     cflags = []
+ }
+
+ # This is included by reference in the //build/config/compiler:runtime_library


### PR DESCRIPTION
Linux: patch updated.
Old patch kept for reference.

Mac and linux: fixed compilation error by removing the `rtc_disable_trace_events` option.