### PR TITLE
Fix depot tools main branch

### DIFF
--- a/build.py
+++ b/build.py
@@ -115,7 +115,7 @@ def setup(conf):
     util.cd(config.DIR_BUILD)
     if os.path.exists(util.getpath(config.PATH_DEPOT_TOOLS)):
         util.cd(config.PATH_DEPOT_TOOLS)
-        util.exec('git', 'checkout', '-f', 'master')
+        util.exec('git', 'checkout', '-f', 'main')
         util.exec('git', 'pull')
     else:
         util.exec('git', 'clone', 'https://chromium.googlesource.com/chromium/tools/depot_tools.git',


### PR DESCRIPTION
## Disclaimer
I managed to build webrtc on Apple Silicon CPUs! 🎉
To do so, just run ` python3 build.py --last --cpu arm64 --os mac --no-log`

## Changes

The main problem was related to the fact that depot tools changed their main branch name from `master` to `main`.

## Github actions

Note: unfortunately, GitHub actions still don't support M1 CPUs (https://github.com/actions/virtual-environments/issues/2187). We could set up an ephemeral self-hosted CI in the meantime (https://www.mirkogalimberti.com/post/2/github-actions-self-hosted-apple-silicon-m1-runner-howto)