### PR TITLE
fix: mac build + linux debug build

### DIFF
--- a/build.py
+++ b/build.py
@@ -94,7 +94,7 @@ def parse_conf(args):
         elif args.stdlib == 'gnu':
             conf['stdlib'] = 'gnu'
     else:
-        conf['stdlib'] = args.stdlib
+        conf['stdlib'] = 'default'
 
     conf['boringssl'] = args.boringssl
 
@@ -185,7 +185,11 @@ def pull(conf):
 
 def patch(conf):
     patches_path = util.getpath(config.DIR_PATCH)
-    patch_key = "_".join([conf['platform'], conf['stdlib']])
+
+    if conf['stdlib'] != 'default':
+        patch_key = "_".join([conf['platform'], conf['stdlib']])
+    else:
+        patch_key = conf['platform']
 
     if patch_key in config.patches.keys():
         for patch in config.patches[patch_key]:

--- a/config.py
+++ b/config.py
@@ -77,6 +77,7 @@ cubbit_default["gn_args"] = [
     'rtc_use_dummy_audio_file_devices=true',
     'rtc_use_x11=false',
     'use_custom_libcxx=false',
+    'use_glib=false',
 
     'rtc_include_tests=false',
     'rtc_disable_metrics=false',
@@ -88,6 +89,15 @@ cubbit_default["gn_args"] = [
 patches = {}
 patches['linux_x64_llvm'] = [
     (os.path.join(PATH_WEBRTC, 'src', 'build'), 'build_config_linux.patch'),
+]
+patches['linux_x64_gnu'] = [
+    (os.path.join(PATH_WEBRTC, 'src', 'base'), 'base_config_linux.patch'),
+]
+patches['win_x64'] = [
+    (os.path.join(PATH_WEBRTC, 'src', 'build'), 'suppress_warnings.patch'),
+]
+patches['mac_x64'] = [
+    (os.path.join(PATH_WEBRTC, 'src', 'build'), 'suppress_warnings.patch'),
 ]
 
 libcxx_url = {}

--- a/patches/base_config_linux.patch
+++ b/patches/base_config_linux.patch
@@ -1,0 +1,13 @@
+diff --git a/containers/flat_tree.cc b/containers/flat_tree.cc
+index bda3855d0..43fd7bcca 100644
+--- a/containers/flat_tree.cc
++++ b/containers/flat_tree.cc
+@@ -8,7 +8,7 @@
+ // on build time. Try not to raise this limit unless absolutely necessary. See
+ // https://chromium.googlesource.com/chromium/src/+/HEAD/docs/wmax_tokens.md
+ #ifndef NACL_TC_REV
+-#pragma clang max_tokens_here 290000
++#pragma clang max_tokens_here 350000
+ #endif
+ 
+ namespace base {

--- a/patches/suppress_warnings.patch
+++ b/patches/suppress_warnings.patch
@@ -1,0 +1,13 @@
+diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
+index af37ee76a..a18537970 100644
+--- a/config/compiler/BUILD.gn
++++ b/config/compiler/BUILD.gn
+@@ -1488,6 +1487,7 @@ config("default_warnings") {
+       # Disables.
+       "-Wno-missing-field-initializers",  # "struct foo f = {0};"
+       "-Wno-unused-parameter",  # Unused function parameters.
++      "-Wno-deprecated-declarations",
+     ]
+   }
+ 
+


### PR DESCRIPTION
This PR removes `libglib` from webrtc because in debug builds it would leave undefined symbols in the final `libwebrtc.a`
I don't know why this was happening only for debugs build and since when it was happening.

I also excluded some warnings in order to fix mac build
- `-Wno-deprecated-declarations`: `std::result_of` has been deprecated since c++17

I tried to iteratively exclude some warnings to fix the windows build, but when I got to the last one I decided to give up because it doesn't seem safe.
- `/wd4715`: not all control path return a value
- `/wd4267`: conversion from 'size_t' to 'int', possible loss of data
- `/wd5105`: macro expansion producing 'defined' has undefined behavior
- `/wd4838`: conversion from 'const double' to 'const ValueType &' requires a narrowing conversion

So the win build is still broken.
